### PR TITLE
support next 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "analyze": "size-limit --why"
   },
   "peerDependencies": {
-    "next": "^9.5.0"
+    "next": "^9.5.0 || ^10.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Hello! This package is really useful, I've been using it for routing on a static build of a next project and it's worked beautifully.

Unfortunately there's been an issue with conflicting peer deps using npm 7, which complains that because some other deps require next ^9.0.0 || ^10.0.0, and others require >=7.0.0,
next-static-manifest specifically requires ^9.5.0, and my project is using next 10.1.3.

I used the  `npm install --legacy-peer-deps` to work around it, but ideally this would be fixed here instead.
(https://docs.npmjs.com/cli/v7/commands/npm-install#configuration-options-affecting-dependency-resolution-and-tree-design
https://twitter.com/wesbos/status/1359173446740172810?lang=en
https://github.com/npm/rfcs/blob/latest/implemented/0025-install-peer-deps.md
)

I've gone for the conservative option here, but happy to change it to >= 9.5.0 if needs be.