### PR TITLE
support next 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "analyze": "size-limit --why"
   },
   "peerDependencies": {
-    "next": "^9.5.0 || ^10.0.0"
+    "next": "^9.5.0 || ^10.0.0 || ^11.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Next has released v11 now, so here's a PR to support it!
https://github.com/vercel/next.js/releases/tag/v11.0.0